### PR TITLE
Migrated System Information configuration to base configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Follow the steps to create your custom configuration file for health API.
 | apiPath | &#9744; | "/status" | API path name |
 | apiSecurity | &#9744; | false | Secure health API with auth token |
 | response| &#9744; | { Object with all true } | Response object customization (You can avoid unwanted properties from health API response) |
+| systemInformation | &#9744;  | { Object with all true } | Customize required system information properties |
 | consumedServicesAsyncMode | &#9744;  | true | Consumed services health check method(Async or Sync based requests to endpoints) |
 | consumedServices | &#9744; | { } | Configuration of all the consumed services |
 | apis | &#9744; | { } | Configuration of all available APIs in the server |
@@ -68,10 +69,6 @@ Follow the steps to create your custom configuration file for health API.
 | Property | Mandatory | Default value | Description |
 | -------  | --------  | ------------- | ----------- |
 | statusCodes | &#9744; | true | Include status codes of health checks with response |
-| systemInfo | &#9744; | { Object with all true } | Include system information with response |
-| ── common | &#9744; | true | Include common(OS, Uptime) information with response |
-| ── cpu | &#9744; | true | Include CPU(Cores, Speeds) information with response |
-| ── memory | &#9744; | true | Include memory(Total, Free) information with response |
 | | |
 
 #### API Security configuration
@@ -107,6 +104,27 @@ when you enable API Security for health API,
     }
    ```
 
+#### System Information configuration
+
+| Property | Mandatory | Default value | Description |
+| -------  | --------  | ------------- | ----------- |
+| systemInformation | &#9744; | { Object with all true } | Customize the system related information |
+| ── common | &#9744; | true | Retrieve common(OS, Uptime) information |
+| ── cpu | &#9744; | true | Retrieve CPU(Cores, Speeds) information |
+| ── memory | &#9744; | true | Retrieve memory(Total, Free) information |
+| | |
+
+This is the example configuration to configure required system information,
+```
+  ...
+  systemInformation: {
+    common: true,
+    cpu: true,
+    memory: true,
+  }
+  ...
+```
+
 #### Consumed services configuration
 
 Structure should follow this pattern : `{ serviceId: { ...service object } }`. Service object properties are,
@@ -139,11 +157,11 @@ Structure should follow this pattern : `{ apiId: { ...api object } }`. API objec
   "apiPath": "/status",             // API Path Name [String]
   "response": {                     // Response configuration [Object]
     "statusCodes": true,            // Attach statusCodes with responses [Boolean]
-    "systemInfo": {                 // Attach system information with responses [Boolean/Object]
-        "common": true,             // Attach common information to systemInfo [Boolean]
-        "cpu": true,                // Attach cpu information to systemInfo [Boolean]
-        "memory": true              // Attach memory information to systemInfo [Boolean]
-    }
+  },
+  "systemInformation": {            // Attach system information with responses [Boolean/Object]
+    "common": true,                 // Attach common information [Boolean]
+    "cpu": true,                    // Attach cpu information [Boolean]
+    "memory": true                  // Attach memory information [Boolean]
   },
   "consumedServicesAsyncMode": false,   // Consumed Services request mode [Boolean]
   "consumedServices": {                 // Consumed services configuration [Object]

--- a/src/configValidator.js
+++ b/src/configValidator.js
@@ -30,41 +30,43 @@ const configValidator = config => {
 
   // Validate responses
   if (config.response) {
-    const { statusCodes, systemInfo } = config.response;
+    const { statusCodes } = config.response;
     if (typeof statusCodes !== "boolean") {
       config.response.statusCodes = defaultConfig.response.statusCodes;
     }
+  } else {
+    config.response = defaultConfig.response;
+  }
 
-    if (systemInfo == undefined) {
-      config.response.systemInfo = defaultConfig.response.systemInfo;
-    }
-    else if (typeof systemInfo === "boolean") {
-      if (systemInfo == true) {
-        config.response.systemInfo = defaultConfig.response.systemInfo;
+  // Validate SystemInformation
+  if (config.systemInformation != undefined) {
+    const { systemInformation } = config;
+    if (typeof systemInformation === "boolean") {
+      if (systemInformation == true) {
+        config.systemInformation = defaultConfig.systemInformation;
       } else {
-        config.response.systemInfo = {
+        config.systemInformation = {
           common: false,
           cpu: false,
           memory: false
         };
       }
-    } else if (typeof systemInfo === "object") {
-      const { common, cpu, memory } = systemInfo;
+    } else if (typeof systemInformation === "object") {
+      const { common, cpu, memory } = systemInformation;
       if (typeof common !== "boolean") {
-        systemInfo.common = true;
+        systemInformation.common = true;
       }
       if (typeof cpu !== "boolean") {
-        systemInfo.cpu = defaultConfig.response.systemInfo.cpu;
+        systemInformation.cpu = defaultConfig.systemInformation.cpu;
       }
       if (typeof memory !== "boolean") {
-        systemInfo.memory = defaultConfig.response.systemInfo.memory;
+        systemInformation.memory = defaultConfig.systemInformation.memory;
       }
     } else {
-      config.response.systemInfo = defaultConfig.response.systemInfo;
+      config.systemInformation = defaultConfig.systemInformation;
     }
-
   } else {
-    config.response = defaultConfig.response;
+    config.systemInformation = defaultConfig.systemInformation;
   }
 
   // validate consumed services

--- a/src/configs/defaultConfig config.json
+++ b/src/configs/defaultConfig config.json
@@ -2,12 +2,12 @@
   "isDefault": true,
   "apiPath": "/status",
   "response": {
-    "statusCodes": true,
-    "systemInfo": {
-      "common": true,
-      "cpu": true,
-      "memory": true
-    }
+    "statusCodes": true
+  },
+  "systemInformation": {
+    "common": true,
+    "cpu": true,
+    "memory": true
   },
   "consumedServicesAsyncMode": true,
   "consumedServices": {},

--- a/src/configs/defaultConfig.js
+++ b/src/configs/defaultConfig.js
@@ -7,11 +7,11 @@ const defaultConfig = {
   },
   response: {
     statusCodes: true,
-    systemInfo: {
-      common: true,
-      cpu: true,
-      memory: true,
-    }
+  },
+  systemInformation: {
+    common: true,
+    cpu: true,
+    memory: true,
   },
   consumedServicesAsyncMode: true,
   consumedServices: {

--- a/src/doHealthCheck.js
+++ b/src/doHealthCheck.js
@@ -10,7 +10,7 @@ const doHealthCheck = async (config) => {
     status: STATUS.UP
   };
 
-  const { consumedServices, apis, consumedServicesAsyncMode, response } = config;
+  const { consumedServices, apis, consumedServicesAsyncMode } = config;
   const consumedServiceStatus = {};
 
   if (!consumedServicesAsyncMode) {
@@ -100,7 +100,7 @@ const doHealthCheck = async (config) => {
     }
   }
 
-  const systemInformation = await collectSystemInformation(response.systemInfo);
+  const systemInformation = await collectSystemInformation(config.systemInformation);
 
   return {
     ...res,

--- a/test/configValidator.test.js
+++ b/test/configValidator.test.js
@@ -94,64 +94,64 @@ describe('should validate configurations through configValidator', () => {
             expect(config.response.statusCodes).is.equal(defaultConfig.response.statusCodes)
         })
 
-        it ("should set valid response.systemInfo if custom config have a invalid property", () => {
-            customConfig.response = { systemInfo: undefined }
+        it ("should set valid systemInformation if custom config have a invalid property", () => {
+            customConfig.systemInformation = undefined;
             let config = configValidator(customConfig);
-            expect(config.response.systemInfo).is.not.undefined;
-            expect(typeof config.response.systemInfo).is.equal("object");
-            expect(config.response.systemInfo).is.equal(defaultConfig.response.systemInfo)
+            expect(config.systemInformation).is.not.undefined;
+            expect(typeof config.systemInformation).is.equal("object");
+            expect(config.systemInformation).is.equal(defaultConfig.systemInformation)
 
-            customConfig.response = { systemInfo: "ABC" }
+            customConfig.systemInformation = "ABC"
             config = configValidator(customConfig);
-            expect(config.response.systemInfo).is.not.equal("ABC");
-            expect(typeof config.response.systemInfo).is.equal("object");
-            expect(config.response.systemInfo).is.equal(defaultConfig.response.systemInfo)
+            expect(config.systemInformation).is.not.equal("ABC");
+            expect(typeof config.systemInformation).is.equal("object");
+            expect(config.systemInformation).is.equal(defaultConfig.systemInformation)
         })
 
-        it ("should response.systemInfo accept booleans to represent the whole response state", () => {
-            customConfig.response = { systemInfo: true }
+        it ("should systemInformation accept booleans to represent the whole response state", () => {
+            customConfig.systemInformation = true 
             let config = configValidator(customConfig);
-            expect(config.response.systemInfo).is.not.true;
-            expect(typeof config.response.systemInfo).is.equal("object");
-            expect(config.response.systemInfo).is.equal(defaultConfig.response.systemInfo)
+            expect(config.systemInformation).is.not.true;
+            expect(typeof config.systemInformation).is.equal("object");
+            expect(config.systemInformation).is.equal(defaultConfig.systemInformation)
 
-            customConfig.response = { systemInfo: false }
+            customConfig.systemInformation = false
             config = configValidator(customConfig);
-            expect(config.response.systemInfo).is.not.false
-            expect(typeof config.response.systemInfo).is.equal("object");
-            expect(config.response.systemInfo.common).false;
-            expect(config.response.systemInfo.cpu).false;
-            expect(config.response.systemInfo.memory).false;
+            expect(config.systemInformation).is.not.false
+            expect(typeof config.systemInformation).is.equal("object");
+            expect(config.systemInformation.common).false;
+            expect(config.systemInformation.cpu).false;
+            expect(config.systemInformation.memory).false;
         })
 
-        it ("should response.systemInfo accept valid object properties to represent the each response state", () => {
-            customConfig.response = { systemInfo: { common: true, cpu: true, memory: true} }
+        it ("should systemInformation accept valid object properties to represent the each response state", () => {
+            customConfig.systemInformation = { common: true, cpu: true, memory: true}
             let config = configValidator(customConfig);
-            expect(typeof config.response.systemInfo).is.equal("object");
-            expect(config.response.systemInfo.common).true;
-            expect(config.response.systemInfo.cpu).true;
-            expect(config.response.systemInfo.memory).true;
+            expect(typeof config.systemInformation).is.equal("object");
+            expect(config.systemInformation.common).true;
+            expect(config.systemInformation.cpu).true;
+            expect(config.systemInformation.memory).true;
 
-            customConfig.response = { systemInfo: { common: true, cpu: false, memory: true} }
+            customConfig.systemInformation = { common: true, cpu: false, memory: true}
             config = configValidator(customConfig);
-            expect(typeof config.response.systemInfo).is.equal("object");
-            expect(config.response.systemInfo.common).true;
-            expect(config.response.systemInfo.cpu).false;
-            expect(config.response.systemInfo.memory).true;
+            expect(typeof config.systemInformation).is.equal("object");
+            expect(config.systemInformation.common).true;
+            expect(config.systemInformation.cpu).false;
+            expect(config.systemInformation.memory).true;
 
-            customConfig.response = { systemInfo: { common: false, cpu: false, memory: false} }
+            customConfig.systemInformation = { common: false, cpu: false, memory: false}
             config = configValidator(customConfig);
-            expect(typeof config.response.systemInfo).is.equal("object");
-            expect(config.response.systemInfo.common).false;
-            expect(config.response.systemInfo.cpu).false;
-            expect(config.response.systemInfo.memory).false;
+            expect(typeof config.systemInformation).is.equal("object");
+            expect(config.systemInformation.common).false;
+            expect(config.systemInformation.cpu).false;
+            expect(config.systemInformation.memory).false;
 
-            customConfig.response = { systemInfo: { common: "Abc", cpu: "123", memory: 45 } }
+            customConfig.systemInformation = { common: "Abc", cpu: "123", memory: 45 }
             config = configValidator(customConfig);
-            expect(typeof config.response.systemInfo).is.equal("object");
-            expect(config.response.systemInfo.common).true;
-            expect(config.response.systemInfo.cpu).true;
-            expect(config.response.systemInfo.memory).true;
+            expect(typeof config.systemInformation).is.equal("object");
+            expect(config.systemInformation.common).true;
+            expect(config.systemInformation.cpu).true;
+            expect(config.systemInformation.memory).true;
         })
     })
 


### PR DESCRIPTION
Migrated System Information configuration to base configuration from `response: { ... }` for better usability with future releases.

```
  ...
  systemInformation: {
    common: true,
    cpu: true,
    memory: true,
  }
  ...
```