### PR TITLE
Integrate process ENV properties for Token

### DIFF
--- a/src/configValidator.js
+++ b/src/configValidator.js
@@ -3,12 +3,17 @@
 
 const defaultConfig = require('./configs/defaultConfig');
 const { REQUEST_TYPES } = require('./utils/apiHelper');
+const { loadConfigPropertiesFromEnv } = require('./envMatcher');
 
-const configValidator = config => {
+const configValidator = apiConfiguration => {
+  let config = apiConfiguration;
   if (!config) {
     const defaultConfigForServer = require('./configs/defaultConfig config.json');
     return defaultConfigForServer;
   }
+
+  // Fetch the properties from ENVs
+  config = loadConfigPropertiesFromEnv(config);
 
   // Assigning isDefault false to indicate the custom config
   config.isDefault = false;

--- a/src/configs/processEnvConfig.js
+++ b/src/configs/processEnvConfig.js
@@ -1,0 +1,5 @@
+const processEnvNames = {
+  AUTH_TOKEN: 'HEALTH_API_AUTH_TOKEN'
+};
+
+module.exports = processEnvNames;

--- a/src/envMatcher.js
+++ b/src/envMatcher.js
@@ -1,0 +1,20 @@
+const processEnvNames = require('./configs/processEnvConfig');
+
+/**
+ * Fetch configuration properties from Node Environment
+ * @param {*} config - Current configuration
+ */
+const loadConfigPropertiesFromEnv = (config) => {
+  const { apiSecurity  } = config;
+  if (process.env[processEnvNames.AUTH_TOKEN]) {
+    config.apiSecurity = {
+      ...apiSecurity,
+      headerToken: process.env[processEnvNames.AUTH_TOKEN]
+    };
+  }
+  return config;
+};
+
+module.exports = {
+  loadConfigPropertiesFromEnv
+};

--- a/test/envMatcher.test.js
+++ b/test/envMatcher.test.js
@@ -1,0 +1,45 @@
+const chai = require('chai');
+const expect = chai.expect;
+const { loadConfigPropertiesFromEnv } = require('../src/envMatcher');
+const processEnvNames = require('../src/configs/processEnvConfig');
+
+describe("should update the properties from Node ENV", () => {
+  beforeEach(() => {
+    process.env[processEnvNames.AUTH_TOKEN] = 'tmp_token'
+  })
+
+  it("should create API_AUTH_TOKEN from ENV if it has a valid ENV property", () => {
+    const mockConfig = {}
+    expect(process.env).haveOwnProperty(processEnvNames.AUTH_TOKEN);
+    expect(process.env[processEnvNames.AUTH_TOKEN]).to.equal('tmp_token')
+    const updatedConfig = loadConfigPropertiesFromEnv(mockConfig);
+    expect(updatedConfig).haveOwnProperty("apiSecurity")
+    expect(updatedConfig.apiSecurity).haveOwnProperty("headerToken")
+    expect(updatedConfig.apiSecurity.headerToken).is.equal("tmp_token")
+  })
+
+  it("should update API_AUTH_TOKEN from ENV if it has a valid ENV property", () => {
+    const token = "token_1";
+    const mockConfig = { apiSecurity: { headerToken: token }}
+    expect(process.env).haveOwnProperty(processEnvNames.AUTH_TOKEN);
+    expect(process.env[processEnvNames.AUTH_TOKEN]).to.equal('tmp_token')
+
+    const updatedConfig = loadConfigPropertiesFromEnv(mockConfig);
+    expect(updatedConfig).haveOwnProperty("apiSecurity")
+    expect(updatedConfig.apiSecurity).haveOwnProperty("headerToken")
+    expect(updatedConfig.apiSecurity.headerToken).is.equal("tmp_token")
+    expect(updatedConfig.apiSecurity.headerToken).is.not.equal(token)
+  })
+
+  it("should update base config header token from ENV if it has a valid ENV property[Not deep clone]", () => {
+    const token = "token_1";
+    const mockConfig = { apiSecurity: { headerToken: token }}
+    expect(process.env).haveOwnProperty(processEnvNames.AUTH_TOKEN);
+    expect(process.env[processEnvNames.AUTH_TOKEN]).to.equal('tmp_token')
+
+    loadConfigPropertiesFromEnv(mockConfig);
+    expect(mockConfig.apiSecurity.headerToken).is.equal("tmp_token")
+    expect(mockConfig.apiSecurity.headerToken).is.not.equal(token)
+  })
+
+})


### PR DESCRIPTION
Added support to fetch token from process ENV properties.

```
HEALTH_API_AUTH_TOKEN=<token> node index.js
```